### PR TITLE
Convert to double early

### DIFF
--- a/R/wrangle.R
+++ b/R/wrangle.R
@@ -144,7 +144,7 @@ key.grouped_df <- function(x,...)sapply(groups(x),as.character)
 # @describeIn wrangle
 
 unsorted.grouped_df <- function(x,...){
-  x$original_ <- seq_len(nrow(x))
+  x$original_ <- as.double(seq_len(nrow(x)))
   x$leads_ <- lead(x$original_,default=Inf)
   x$lags_ <- lag(x$original_,default=-Inf)
   x %<>% sort


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`lead()` and `lag()` are now type stable and cast `default` to the type of `x`. In your package, `Inf` was being used as a default when `x` was an integer vector, which no longer works. It is easy to fix by converting `x` to double first.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!